### PR TITLE
Fix incorrect version in package.json.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native",
-  "version": "0.3.1",
+  "version": "0.3.4",
   "description": "A framework for building native apps using React",
   "repository": {
     "type": "git",


### PR DESCRIPTION
I think the latest version should be `0.3.4` as it shows so on npm website: 
![image](https://cloud.githubusercontent.com/assets/2840571/6967742/d508502e-d993-11e4-81a4-b847a6bf0e2c.png)

Please also ref to this commit: https://github.com/facebook/react-native/commit/db3a724bb25d0a6c17d563be624c04621643995a#diff-b9cfc7f2cdf78a7f4b91a753d10865a2R3
